### PR TITLE
Enable extension for Svelte templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"onLanguage:php",
 		"onLanguage:twig",
 		"onLanguage:blade",
-		"onLanguage:vue-html"
+		"onLanguage:vue-html",
+		"onLanguage:svelte"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Similar to Vue support, just needed an `onLanguage` tag in the package.json and it works great!